### PR TITLE
Support Multiple Spaces in a Payload message without breaking downward Compatibility.

### DIFF
--- a/ffxiv2Mqtt/Ffxiv2Mqtt.cs
+++ b/ffxiv2Mqtt/Ffxiv2Mqtt.cs
@@ -98,20 +98,28 @@ public class Ffxiv2Mqtt : IDalamudPlugin
             case TestCommandName:
                 Service.MqttManager.PublishMessage("test", "success");
                 break;
-            case CustomCommandName:
+            case CustomCommandName: 
             {
-                var argsList = args.Split(' ');
+				var spaceIndex = args.IndexOf(' ');
 
-                if (argsList.Length < 2) {
-                    Service.Log.Error("Not enough arguments.");
-                    return;
-                }
+				if (spaceIndex == -1) {
+					Service.Log.Error("Not enough arguments. Please provide both a topic and a payload.");
+					break;
+				}
 
-                Service.Log.Information($"Publishing a custom message. topic: {argsList[0]} payload: {argsList[1]}");
-                Service.MqttManager.PublishMessage(argsList[0], argsList[1]);
-                break;
-            }
-        }
+				var topic = args.Substring(0, spaceIndex);
+				var payload = args.Substring(spaceIndex + 1);
+
+				if (string.IsNullOrWhiteSpace(payload)) {
+					Service.Log.Error("Payload cannot be empty.");
+					break;
+				}
+
+				Service.Log.Information($"Publishing a custom message. topic: {topic} payload: {payload}");
+				Service.MqttManager.PublishMessage(topic, payload);
+				break;
+			}
+		}
     }
 
     private void DrawMainWindow() { windowSystem.Draw(); }


### PR DESCRIPTION
This PR adds the ability for payloads to have multiple spaces in them and still be send correctly, instead of being cut off after the first space. 

It keeps downwards compatibility to allowing single spaces as well, so no adjustments should be needed. 

Excuse not opening an issue first, the change was so quick to implement that even if you should deem it redundant it would have taken equal amounts of time to write a Issue. 