### PR TITLE
Add CrossRealmParty topic for cross-world party member tracking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,21 @@ jobs:
         with:
           dotnet-version: '8.x'
 
+      - name: Download Dalamud
+        run: |
+          Invoke-WebRequest -Uri "https://goatcorp.github.io/dalamud-distrib/stg/latest.zip" -OutFile dalamud.zip
+          Expand-Archive -Path dalamud.zip -DestinationPath dalamud -Force
+        shell: pwsh
+
       - name: Restore dependencies
         run: dotnet restore ffxiv2Mqtt/Ffxiv2Mqtt.csproj
+        env:
+          DALAMUD_HOME: ${{ github.workspace }}/dalamud
 
       - name: Build
         run: dotnet build ffxiv2Mqtt/Ffxiv2Mqtt.csproj --configuration Release --no-restore
+        env:
+          DALAMUD_HOME: ${{ github.workspace }}/dalamud
 
       - name: Collect output files
         run: |
@@ -44,6 +54,6 @@ jobs:
         with:
           tag_name: build-${{ github.run_number }}
           name: "Build #${{ github.run_number }}"
-          body: "Automatischer Build aus dem Fork mit CrossRealmParty-Unterstützung."
+          body: "Automatischer Build mit CrossRealmParty-Unterstützung."
           files: artifact/*
           make_latest: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build Plugin
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.x'
+
+      - name: Restore dependencies
+        run: dotnet restore ffxiv2Mqtt/Ffxiv2Mqtt.csproj
+
+      - name: Build
+        run: dotnet build ffxiv2Mqtt/Ffxiv2Mqtt.csproj --configuration Release --no-restore
+
+      - name: Collect output files
+        run: |
+          New-Item -ItemType Directory -Force -Path artifact
+          Copy-Item ffxiv2Mqtt/bin/Release/Ffxiv2Mqtt/* -Destination artifact/ -Recurse
+        shell: pwsh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Ffxiv2Mqtt-plugin
+          path: artifact/
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: build-${{ github.run_number }}
+          name: "Build #${{ github.run_number }}"
+          body: "Automatischer Build aus dem Fork mit CrossRealmParty-Unterstützung."
+          files: artifact/*
+          make_latest: true

--- a/ffxiv2Mqtt/Configuration.cs
+++ b/ffxiv2Mqtt/Configuration.cs
@@ -31,4 +31,10 @@ public class Configuration : IPluginConfiguration
     public void Initialize(IDalamudPluginInterface pluginInterface) { this.pluginInterface = pluginInterface; }
 
     public void Save() { pluginInterface!.SavePluginConfig(this); }
+    /// <summary>
+    /// When true, the plugin subscribes to ffxiv/Command/Chat and
+    /// forwards incoming payloads to the in-game chat/command pipeline.
+    /// </summary>
+    public bool EnableCommandReceiver { get; set; } = true;
+
 }

--- a/ffxiv2Mqtt/Ffxiv2Mqtt.cs
+++ b/ffxiv2Mqtt/Ffxiv2Mqtt.cs
@@ -46,7 +46,7 @@ public class Ffxiv2Mqtt : IDalamudPlugin
         PluginInterface.Create<Service>();
         Service.PlayerEvents = new PlayerEvents();
         Service.MqttManager  = new MqttManager(Configuration);
-        Service.CommandReceiver = new MqttCommandReceiver(Service.MqttManager, Service.CommandManager, Service.ChatGui, Service.ClientState, Service.Framework, Service.Log, Configuration);
+        Service.CommandReceiver = new MqttCommandReceiver(Service.MqttManager, Service.CommandManager, Service.ChatGui, Service.PlayerState, Service.Framework, Service.Log, Configuration);
 
         if (Configuration.ConnectAtStartup)
             Service.MqttManager.ConnectToBroker();

--- a/ffxiv2Mqtt/Ffxiv2Mqtt.cs
+++ b/ffxiv2Mqtt/Ffxiv2Mqtt.cs
@@ -46,7 +46,7 @@ public class Ffxiv2Mqtt : IDalamudPlugin
         PluginInterface.Create<Service>();
         Service.PlayerEvents = new PlayerEvents();
         Service.MqttManager  = new MqttManager(Configuration);
-        Service.CommandReceiver = new MqttCommandReceiver(Service.MqttManager, Service.CommandManager, Service.ChatGui, Service.ClientState, Service.Framework, Service.Log, Configuration);
+        Service.CommandReceiver = new MqttCommandReceiver(Service.MqttManager, Service.CommandManager, Service.ChatGui, Service.ClientState, Service.Framework, Service.Log, Configuration, Service.SigScanner);
 
         if (Configuration.ConnectAtStartup)
             Service.MqttManager.ConnectToBroker();

--- a/ffxiv2Mqtt/Ffxiv2Mqtt.cs
+++ b/ffxiv2Mqtt/Ffxiv2Mqtt.cs
@@ -46,7 +46,7 @@ public class Ffxiv2Mqtt : IDalamudPlugin
         PluginInterface.Create<Service>();
         Service.PlayerEvents = new PlayerEvents();
         Service.MqttManager  = new MqttManager(Configuration);
-        Service.CommandReceiver = new MqttCommandReceiver(Service.MqttManager, Service.CommandManager, Service.ChatGui, Service.PlayerState, Service.Framework, Service.Log, Configuration);
+        Service.CommandReceiver = new MqttCommandReceiver(Service.MqttManager, Service.CommandManager, Service.ChatGui, Service.ClientState, Service.Framework, Service.Log, Configuration);
 
         if (Configuration.ConnectAtStartup)
             Service.MqttManager.ConnectToBroker();

--- a/ffxiv2Mqtt/Ffxiv2Mqtt.cs
+++ b/ffxiv2Mqtt/Ffxiv2Mqtt.cs
@@ -46,7 +46,7 @@ public class Ffxiv2Mqtt : IDalamudPlugin
         PluginInterface.Create<Service>();
         Service.PlayerEvents = new PlayerEvents();
         Service.MqttManager  = new MqttManager(Configuration);
-        Service.CommandReceiver = new MqttCommandReceiver(Service.MqttManager, Service.CommandManager, Service.ChatGui, Service.ClientState, Service.Framework, Service.Log, Configuration, Service.SigScanner);
+        Service.CommandReceiver = new MqttCommandReceiver(Service.MqttManager, Service.CommandManager, Service.ChatGui, Service.ClientState, Service.Framework, Service.Log, Configuration);
 
         if (Configuration.ConnectAtStartup)
             Service.MqttManager.ConnectToBroker();

--- a/ffxiv2Mqtt/Ffxiv2Mqtt.cs
+++ b/ffxiv2Mqtt/Ffxiv2Mqtt.cs
@@ -46,6 +46,7 @@ public class Ffxiv2Mqtt : IDalamudPlugin
         PluginInterface.Create<Service>();
         Service.PlayerEvents = new PlayerEvents();
         Service.MqttManager  = new MqttManager(Configuration);
+        Service.CommandReceiver = new MqttCommandReceiver(Service.MqttManager, Service.CommandManager, Service.ChatGui, Service.ClientState, Service.Framework, Service.Log, Configuration);
 
         if (Configuration.ConnectAtStartup)
             Service.MqttManager.ConnectToBroker();
@@ -139,5 +140,6 @@ public class Ffxiv2Mqtt : IDalamudPlugin
         CommandManager.RemoveHandler(TestCommandName);
         CommandManager.RemoveHandler(CustomCommandName);
         Service.MqttManager.Dispose();
+        Service.CommandReceiver.Dispose();
     }
 }

--- a/ffxiv2Mqtt/Service.cs
+++ b/ffxiv2Mqtt/Service.cs
@@ -29,6 +29,7 @@ public class Service
     [PluginService] public static ICondition Condition { get; private set; }
     [PluginService] public static INotificationManager NotificationManager { get; private set; }
     [PluginService] public static IPluginLog Log { get; private set; }
+    [PluginService] public static IGameInteropProvider GameInterop { get; private set; }
     [PluginService] public static IAddonLifecycle AddonLifecycle { get; private set; }
 }
 #pragma warning restore CS8618

--- a/ffxiv2Mqtt/Service.cs
+++ b/ffxiv2Mqtt/Service.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
@@ -10,22 +10,24 @@ namespace Ffxiv2Mqtt;
 [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Local")]
 public class Service
 {
-    internal static               PlayerEvents           PlayerEvents;
-    internal static               MqttManager            MqttManager;
-    [PluginService] public static IDalamudPluginInterface PluginInterface     { get; private set; }
-    [PluginService] public static IChatGui               ChatGui             { get; private set; }
-    [PluginService] public static IToastGui              ToastGui            { get; private set; }
-    [PluginService] public static IClientState           ClientState         { get; private set; }
-    [PluginService] public static IPartyList             PartyList           { get; private set; }
-    [PluginService] public static ICommandManager        CommandManager      { get; private set; }
-    [PluginService] public static IDataManager           DataManager         { get; private set; }
-    [PluginService] public static IFramework             Framework           { get; private set; }
-    [PluginService] public static IObjectTable           ObjectTable         { get; private set; }
-    [PluginService] public static IGameGui               GameGui             { get; private set; }
-    [PluginService] public static IDutyState             DutyState           { get; private set; }
-    [PluginService] public static IJobGauges             JobGauges           { get; private set; }
-    [PluginService] public static ICondition             Condition           { get; private set; }
-    [PluginService] public static INotificationManager   NotificationManager { get; private set; }
-    [PluginService] public static IPluginLog             Log                 { get; private set; }
+    internal static PlayerEvents PlayerEvents;
+    internal static MqttManager MqttManager;
+
+    [PluginService] public static IDalamudPluginInterface PluginInterface { get; private set; }
+    [PluginService] public static IChatGui ChatGui { get; private set; }
+    [PluginService] public static IToastGui ToastGui { get; private set; }
+    [PluginService] public static IClientState ClientState { get; private set; }
+    [PluginService] public static IPartyList PartyList { get; private set; }
+    [PluginService] public static ICommandManager CommandManager { get; private set; }
+    [PluginService] public static IDataManager DataManager { get; private set; }
+    [PluginService] public static IFramework Framework { get; private set; }
+    [PluginService] public static IObjectTable ObjectTable { get; private set; }
+    [PluginService] public static IGameGui GameGui { get; private set; }
+    [PluginService] public static IDutyState DutyState { get; private set; }
+    [PluginService] public static IJobGauges JobGauges { get; private set; }
+    [PluginService] public static ICondition Condition { get; private set; }
+    [PluginService] public static INotificationManager NotificationManager { get; private set; }
+    [PluginService] public static IPluginLog Log { get; private set; }
+    [PluginService] public static IAddonLifecycle AddonLifecycle { get; private set; }
 }
 #pragma warning restore CS8618

--- a/ffxiv2Mqtt/Service.cs
+++ b/ffxiv2Mqtt/Service.cs
@@ -29,7 +29,6 @@ public class Service
     [PluginService] public static ICondition Condition { get; private set; }
     [PluginService] public static INotificationManager NotificationManager { get; private set; }
     [PluginService] public static IPluginLog Log { get; private set; }
-    [PluginService] public static ISigScanner SigScanner { get; private set; }
     [PluginService] public static IAddonLifecycle AddonLifecycle { get; private set; }
 }
 #pragma warning restore CS8618

--- a/ffxiv2Mqtt/Service.cs
+++ b/ffxiv2Mqtt/Service.cs
@@ -12,6 +12,7 @@ public class Service
 {
     internal static PlayerEvents PlayerEvents;
     internal static MqttManager MqttManager;
+    internal static MqttCommandReceiver CommandReceiver;
 
     [PluginService] public static IDalamudPluginInterface PluginInterface { get; private set; }
     [PluginService] public static IChatGui ChatGui { get; private set; }

--- a/ffxiv2Mqtt/Service.cs
+++ b/ffxiv2Mqtt/Service.cs
@@ -29,6 +29,7 @@ public class Service
     [PluginService] public static ICondition Condition { get; private set; }
     [PluginService] public static INotificationManager NotificationManager { get; private set; }
     [PluginService] public static IPluginLog Log { get; private set; }
+    [PluginService] public static IGameInventory GameInventory { get; private set; }
     [PluginService] public static IAddonLifecycle AddonLifecycle { get; private set; }
 }
 #pragma warning restore CS8618

--- a/ffxiv2Mqtt/Service.cs
+++ b/ffxiv2Mqtt/Service.cs
@@ -29,7 +29,7 @@ public class Service
     [PluginService] public static ICondition Condition { get; private set; }
     [PluginService] public static INotificationManager NotificationManager { get; private set; }
     [PluginService] public static IPluginLog Log { get; private set; }
-    [PluginService] public static IGameInteropProvider GameInterop { get; private set; }
+    [PluginService] public static ISigScanner SigScanner { get; private set; }
     [PluginService] public static IAddonLifecycle AddonLifecycle { get; private set; }
 }
 #pragma warning restore CS8618

--- a/ffxiv2Mqtt/Services/ChatBoxHelper.cs
+++ b/ffxiv2Mqtt/Services/ChatBoxHelper.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using FFXIVClientStructs.FFXIV.Client.UI;
+
+namespace Ffxiv2Mqtt.Services;
+
+/// <summary>
+/// Sends a string into the game's native chat input pipeline,
+/// exactly as if the player had typed it and pressed Enter.
+///
+/// This allows commands like /gearset, /micon, /ac, /wait, as well as
+/// any text that native macros support.
+///
+/// Must be called on the Framework (main game) thread.
+/// </summary>
+public static unsafe class ChatBoxHelper
+{
+    private static readonly ProcessChatBoxDelegate? _processChatBox;
+    private delegate void ProcessChatBoxDelegate(UIModule* uiModule, nint message, nint unused, byte a4);
+
+    static ChatBoxHelper()
+    {
+        _processChatBox = GetProcessChatBox();
+    }
+
+    private static ProcessChatBoxDelegate? GetProcessChatBox()
+    {
+        try
+        {
+            var uiModule = UIModule.Instance();
+            if (uiModule == null) return null;
+            // VTable slot 26 = ProcessChatBoxInput (same as SomethingNeedDoing, QoLBar)
+            const int VTableSlot = 26;
+            var vtable = *(nint**)uiModule;
+            var fnPtr  = vtable[VTableSlot];
+            return Marshal.GetDelegateForFunctionPointer<ProcessChatBoxDelegate>(fnPtr);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Sends <paramref name="message"/> into the game chat/command processor.
+    /// Call this on the Framework thread only.
+    /// </summary>
+    public static void SendMessage(string message)
+    {
+        if (_processChatBox == null)
+            throw new InvalidOperationException("ChatBoxHelper: ProcessChatBox function pointer not resolved.");
+
+        var uiModule = UIModule.Instance();
+        if (uiModule == null)
+            throw new InvalidOperationException("ChatBoxHelper: UIModule not available.");
+
+        var bytes = Encoding.UTF8.GetBytes(message + "\0");
+        fixed (byte* ptr = bytes)
+        {
+            using var mem = new LocalMemory(bytes.Length + 30);
+            mem.Write(ptr, bytes.Length);
+            _processChatBox(uiModule, mem.Address, nint.Zero, 0);
+        }
+    }
+
+    private sealed class LocalMemory : IDisposable
+    {
+        public nint Address { get; }
+        public LocalMemory(int length)
+        {
+            Address = Marshal.AllocHGlobal(length);
+            for (var i = 0; i < length; i++)
+                Marshal.WriteByte(Address, i, 0);
+        }
+        public unsafe void Write(byte* src, int count)
+        {
+            for (var i = 0; i < count; i++)
+                Marshal.WriteByte(Address, i, src[i]);
+        }
+        public void Dispose() => Marshal.FreeHGlobal(Address);
+    }
+}

--- a/ffxiv2Mqtt/Services/IMqttClientWrapper.cs
+++ b/ffxiv2Mqtt/Services/IMqttClientWrapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using MQTTnet;
+using MQTTnet.Client;
 using MQTTnet.Protocol;
 
 namespace Ffxiv2Mqtt.Services;

--- a/ffxiv2Mqtt/Services/IMqttClientWrapper.cs
+++ b/ffxiv2Mqtt/Services/IMqttClientWrapper.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using MQTTnet;
+using MQTTnet.Protocol;
+
+namespace Ffxiv2Mqtt.Services;
+
+/// <summary>
+/// Minimal interface that MqttManager must implement so that
+/// MqttCommandReceiver can hook into the client lifecycle without
+/// depending on the concrete MqttManager class directly.
+/// </summary>
+public interface IMqttClientWrapper
+{
+    /// <summary>Raised when the MQTT connection is established.</summary>
+    event EventHandler? Connected;
+
+    /// <summary>Raised when the MQTT connection is lost or closed.</summary>
+    event EventHandler? Disconnected;
+
+    /// <summary>Raised for every incoming MQTT message.</summary>
+    event EventHandler<MqttApplicationMessageReceivedEventArgs>? MessageReceived;
+
+    /// <summary>Subscribe to a topic.</summary>
+    Task SubscribeAsync(string topic, MqttQualityOfServiceLevel qos);
+}

--- a/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
+++ b/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.UI;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Protocol;
@@ -14,28 +15,21 @@ namespace Ffxiv2Mqtt.Services;
 /// Subscribes to the MQTT command topic and forwards received payloads
 /// into the FFXIV in-game chat / command pipeline.
 ///
-/// Topic layout:
-///   Default:   ffxiv/Command/Chat
-///   With ID:   ffxiv/{ClientId}/Command/Chat
+/// Topic:   ffxiv/Command/Chat  (or ffxiv/{ClientId}/Command/Chat)
 ///
 /// Payload rules:
-///   Starts with '/'  -> slash command via ICommandManager or native ChatBox
-///   Plain text       -> printed to local chat as info message
-///
-/// Safety guards:
-///   - Max payload length: 500 chars
-///   - Always marshalled onto Framework thread
-///   - Only runs while a local player is logged in
+///   Starts with '/'  -> executed as slash command via ProcessCommand or ChatBox
+///   Plain text       -> printed to local chat with [MQTT] prefix
 /// </summary>
-public sealed class MqttCommandReceiver : IDisposable
+public sealed unsafe class MqttCommandReceiver : IDisposable
 {
-    private readonly IMqttClientWrapper    mqttClient;
-    private readonly ICommandManager       commandManager;
-    private readonly IChatGui              chatGui;
-    private readonly IClientState          clientState;
-    private readonly IFramework            framework;
-    private readonly IPluginLog            log;
-    private readonly Configuration         config;
+    private readonly IMqttClientWrapper mqttClient;
+    private readonly ICommandManager    commandManager;
+    private readonly IChatGui           chatGui;
+    private readonly IClientState       clientState;
+    private readonly IFramework         framework;
+    private readonly IPluginLog         log;
+    private readonly Configuration      config;
 
     private string subscribedTopic = string.Empty;
 
@@ -73,10 +67,9 @@ public sealed class MqttCommandReceiver : IDisposable
     {
         if (!config.EnableCommandReceiver)
         {
-            log.Debug("[CommandReceiver] Disabled in config - skipping subscribe.");
+            log.Debug("[CommandReceiver] Disabled in config.");
             return;
         }
-
         subscribedTopic = BuildTopic();
         try
         {
@@ -100,57 +93,79 @@ public sealed class MqttCommandReceiver : IDisposable
         if (!string.Equals(topic, subscribedTopic, StringComparison.OrdinalIgnoreCase))
             return;
 
-        var raw = Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment);
+        var raw = Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment).Trim();
+
+        // Strip surrounding quotes that Home Assistant may add
+        if (raw.Length >= 2 && raw[0] == '"' && raw[^1] == '"')
+            raw = raw[1..^1].Trim();
 
         if (string.IsNullOrWhiteSpace(raw))
         {
-            log.Warning("[CommandReceiver] Received empty payload - ignored.");
+            log.Warning("[CommandReceiver] Empty payload – ignored.");
             return;
         }
 
         if (raw.Length > 500)
         {
-            log.Warning($"[CommandReceiver] Payload too long ({raw.Length} chars) - ignored.");
+            log.Warning($"[CommandReceiver] Payload too long ({raw.Length}) – ignored.");
             return;
         }
 
-        log.Debug($"[CommandReceiver] Incoming on '{topic}': {raw}");
-        framework.RunOnFrameworkThread(() => Execute(raw.Trim()));
+        log.Debug($"[CommandReceiver] Received: {raw}");
+        framework.RunOnFrameworkThread(() => Execute(raw));
     }
 
     private void Execute(string payload)
     {
+#pragma warning disable CS0618
         if (clientState.LocalPlayer == null)
+#pragma warning restore CS0618
         {
-            log.Warning("[CommandReceiver] Command received but no player is logged in - ignored.");
+            log.Warning("[CommandReceiver] No player logged in – ignored.");
             return;
         }
 
         if (payload.StartsWith('/'))
-            ExecuteCommand(payload);
+        {
+            // 1. Try Dalamud-registered commands (plugin commands)
+            if (commandManager.ProcessCommand(payload))
+            {
+                log.Debug($"[CommandReceiver] Dalamud command executed: {payload}");
+                return;
+            }
+
+            // 2. Native game command via UIModule (same as typing in chat box)
+            SendNativeCommand(payload);
+        }
         else
         {
+            // Plain text: print to local chat
             var msg = new SeStringBuilder()
                 .AddUiForeground("[MQTT] ", 32)
                 .AddText(payload)
                 .Build();
             chatGui.Print(new XivChatEntry { Message = msg });
-            log.Debug($"[CommandReceiver] Printed plain-text: {payload}");
         }
     }
 
-    private void ExecuteCommand(string command)
+    private void SendNativeCommand(string command)
     {
-        if (commandManager.ProcessCommand(command))
-        {
-            log.Debug($"[CommandReceiver] Dispatched Dalamud command: {command}");
-            return;
-        }
-
         try
         {
-            ChatBoxHelper.SendMessage(command);
-            log.Debug($"[CommandReceiver] Sent native game command: {command}");
+            var uiModule = UIModule.Instance();
+            if (uiModule == null)
+            {
+                log.Error("[CommandReceiver] UIModule unavailable.");
+                return;
+            }
+
+            var bytes = Encoding.UTF8.GetBytes(command + "\0");
+            fixed (byte* ptr = bytes)
+            {
+                var ptrInt = (nint)ptr;
+                uiModule->ProcessChatBoxEntry((Utf8String*)&ptrInt);
+            }
+            log.Debug($"[CommandReceiver] Native command sent: {command}");
         }
         catch (Exception ex)
         {

--- a/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
+++ b/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
@@ -1,19 +1,29 @@
 using System;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Dalamud.Game;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Plugin.Services;
-using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Client.UI;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Protocol;
 
 namespace Ffxiv2Mqtt.Services;
 
-public sealed unsafe class MqttCommandReceiver : IDisposable
+/// <summary>
+/// Subscribes to MQTT and forwards payloads as in-game commands.
+/// Topic: ffxiv/Command/Chat  (or ffxiv/{ClientId}/Command/Chat)
+/// </summary>
+public sealed class MqttCommandReceiver : IDisposable
 {
+    // Signature for ProcessChatBox - stable across patches
+    // Same sig used by SomethingNeedDoing, QoLBar, etc.
+    private delegate void ProcessChatBoxDelegate(nint uiModule, nint message, nint unused, byte a4);
+    private readonly ProcessChatBoxDelegate? processChatBox;
+    private readonly nint uiModulePtr;
+
     private readonly IMqttClientWrapper mqttClient;
     private readonly ICommandManager    commandManager;
     private readonly IChatGui           chatGui;
@@ -21,6 +31,7 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
     private readonly IFramework         framework;
     private readonly IPluginLog         log;
     private readonly Configuration      config;
+    private readonly ISigScanner        sigScanner;
 
     private string subscribedTopic = string.Empty;
 
@@ -31,7 +42,8 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
         IClientState       clientState,
         IFramework         framework,
         IPluginLog         log,
-        Configuration      config)
+        Configuration      config,
+        ISigScanner        sigScanner)
     {
         this.mqttClient     = mqttClient;
         this.commandManager = commandManager;
@@ -40,6 +52,20 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
         this.framework      = framework;
         this.log            = log;
         this.config         = config;
+        this.sigScanner     = sigScanner;
+
+        // Resolve ProcessChatBox function pointer via signature scan
+        try
+        {
+            var fnPtr = sigScanner.ScanText("48 89 5C 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 45 84 C9");
+            processChatBox = Marshal.GetDelegateForFunctionPointer<ProcessChatBoxDelegate>(fnPtr);
+            uiModulePtr    = sigScanner.GetStaticAddressFromSig("48 8B 0D ?? ?? ?? ?? 48 8D 54 24 ?? 48 83 C1 10 E8");
+            log.Debug("[CommandReceiver] ProcessChatBox resolved.");
+        }
+        catch (Exception ex)
+        {
+            log.Error(ex, "[CommandReceiver] Could not resolve ProcessChatBox signature.");
+        }
 
         this.mqttClient.Connected       += OnConnected;
         this.mqttClient.Disconnected    += OnDisconnected;
@@ -74,6 +100,7 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
             return;
 
         var raw = Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment).Trim();
+        // Strip surrounding quotes HA may add
         if (raw.Length >= 2 && raw[0] == '"' && raw[^1] == '"')
             raw = raw[1..^1].Trim();
         if (string.IsNullOrWhiteSpace(raw) || raw.Length > 500) return;
@@ -90,11 +117,13 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
 
         if (payload.StartsWith('/'))
         {
+            // Try Dalamud commands first (plugin commands like /xlsettings etc.)
             if (commandManager.ProcessCommand(payload))
             {
                 log.Debug($"[CommandReceiver] Dalamud command: {payload}");
                 return;
             }
+            // Fall back to native game ChatBox (handles /gearset, /ac, /wait, etc.)
             SendToGameChatBox(payload);
         }
         else
@@ -109,21 +138,25 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
 
     private void SendToGameChatBox(string message)
     {
+        if (processChatBox == null)
+        {
+            log.Error("[CommandReceiver] ProcessChatBox not available.");
+            chatGui.PrintError($"[MQTT] Cannot send native command: {message}");
+            return;
+        }
+
         try
         {
-            var uiModule = UIModule.Instance();
-            if (uiModule == null) { log.Error("[CommandReceiver] UIModule null."); return; }
-
-            var utf8 = new Utf8String();
-            utf8.SetString(message);
-            uiModule->ProcessChatBoxEntry(&utf8);
-            utf8.Dtor();
-
-            log.Debug($"[CommandReceiver] Native command: {message}");
+            var bytes  = Encoding.UTF8.GetBytes(message + "\0");
+            var handle = Marshal.AllocHGlobal(bytes.Length + 32);
+            Marshal.Copy(bytes, 0, handle, bytes.Length);
+            processChatBox(uiModulePtr, handle, nint.Zero, 0);
+            Marshal.FreeHGlobal(handle);
+            log.Debug($"[CommandReceiver] Native command sent: {message}");
         }
         catch (Exception ex)
         {
-            log.Error(ex, $"[CommandReceiver] Failed: {message}");
+            log.Error(ex, $"[CommandReceiver] SendToGameChatBox failed: {message}");
             chatGui.PrintError($"[MQTT] Failed: {message}");
         }
     }

--- a/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
+++ b/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
@@ -5,6 +5,7 @@ using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Plugin.Services;
 using MQTTnet;
+using MQTTnet.Client;
 using MQTTnet.Protocol;
 
 namespace Ffxiv2Mqtt.Services;
@@ -140,14 +141,12 @@ public sealed class MqttCommandReceiver : IDisposable
 
     private void ExecuteCommand(string command)
     {
-        // 1. Try Dalamud-registered commands first
         if (commandManager.ProcessCommand(command))
         {
             log.Debug($"[CommandReceiver] Dispatched Dalamud command: {command}");
             return;
         }
 
-        // 2. Fall back to native game input (/gearset, /micon, etc.)
         try
         {
             ChatBoxHelper.SendMessage(command);

--- a/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
+++ b/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Plugin.Services;
-using Dalamud.Game.ClientState;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Protocol;
@@ -33,7 +32,7 @@ public sealed class MqttCommandReceiver : IDisposable
     private readonly IMqttClientWrapper    mqttClient;
     private readonly ICommandManager       commandManager;
     private readonly IChatGui              chatGui;
-    private readonly IPlayerState          playerState;
+    private readonly IClientState          clientState;
     private readonly IFramework            framework;
     private readonly IPluginLog            log;
     private readonly Configuration         config;
@@ -44,7 +43,7 @@ public sealed class MqttCommandReceiver : IDisposable
         IMqttClientWrapper mqttClient,
         ICommandManager    commandManager,
         IChatGui           chatGui,
-        IPlayerState       playerState,
+        IClientState       clientState,
         IFramework         framework,
         IPluginLog         log,
         Configuration      config)
@@ -52,7 +51,7 @@ public sealed class MqttCommandReceiver : IDisposable
         this.mqttClient     = mqttClient;
         this.commandManager = commandManager;
         this.chatGui        = chatGui;
-        this.playerState    = playerState;
+        this.clientState    = clientState;
         this.framework      = framework;
         this.log            = log;
         this.config         = config;
@@ -121,7 +120,7 @@ public sealed class MqttCommandReceiver : IDisposable
 
     private void Execute(string payload)
     {
-        if (playerState.IsNotLoaded)
+        if (clientState.LocalPlayer == null)
         {
             log.Warning("[CommandReceiver] Command received but no player is logged in - ignored.");
             return;

--- a/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
+++ b/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
@@ -20,7 +20,7 @@ namespace Ffxiv2Mqtt.Services;
 /// Native command dispatch mirrors XIVDeck's ChatHelper exactly:
 /// https://github.com/KazWolfe/XIVDeck/blob/main/FFXIVPlugin/Game/Chat/ChatHelper.cs
 /// </summary>
-public sealed unsafe class MqttCommandReceiver : IDisposable
+public sealed class MqttCommandReceiver : IDisposable
 {
     private readonly IMqttClientWrapper mqttClient;
     private readonly ICommandManager    commandManager;
@@ -122,7 +122,7 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
     /// Mirrors XIVDeck ChatHelper.SendSanitizedChatMessage() exactly.
     /// Utf8String.FromString -> SanitizeString -> ProcessChatBoxEntry(msg, nint.Zero) -> Dtor(true)
     /// </summary>
-    private void SendNativeCommand(string command)
+    private unsafe void SendNativeCommand(string command)
     {
         try
         {

--- a/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
+++ b/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using MQTTnet;
 using MQTTnet.Client;
@@ -11,16 +12,6 @@ using MQTTnet.Protocol;
 
 namespace Ffxiv2Mqtt.Services;
 
-/// <summary>
-/// Subscribes to the MQTT command topic and forwards received payloads
-/// into the FFXIV in-game chat / command pipeline.
-///
-/// Topic:   ffxiv/Command/Chat  (or ffxiv/{ClientId}/Command/Chat)
-///
-/// Payload rules:
-///   Starts with '/'  -> executed as slash command via ProcessCommand or ChatBox
-///   Plain text       -> printed to local chat with [MQTT] prefix
-/// </summary>
 public sealed unsafe class MqttCommandReceiver : IDisposable
 {
     private readonly IMqttClientWrapper mqttClient;
@@ -65,51 +56,27 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
 
     private async void OnConnected(object? sender, EventArgs e)
     {
-        if (!config.EnableCommandReceiver)
-        {
-            log.Debug("[CommandReceiver] Disabled in config.");
-            return;
-        }
+        if (!config.EnableCommandReceiver) return;
         subscribedTopic = BuildTopic();
         try
         {
             await mqttClient.SubscribeAsync(subscribedTopic, MqttQualityOfServiceLevel.AtLeastOnce);
             log.Information($"[CommandReceiver] Subscribed to '{subscribedTopic}'");
         }
-        catch (Exception ex)
-        {
-            log.Error(ex, "[CommandReceiver] Failed to subscribe.");
-        }
+        catch (Exception ex) { log.Error(ex, "[CommandReceiver] Subscribe failed."); }
     }
 
-    private void OnDisconnected(object? sender, EventArgs e)
-    {
-        subscribedTopic = string.Empty;
-    }
+    private void OnDisconnected(object? sender, EventArgs e) => subscribedTopic = string.Empty;
 
     private void OnMessageReceived(object? sender, MqttApplicationMessageReceivedEventArgs e)
     {
-        var topic = e.ApplicationMessage.Topic;
-        if (!string.Equals(topic, subscribedTopic, StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(e.ApplicationMessage.Topic, subscribedTopic, StringComparison.OrdinalIgnoreCase))
             return;
 
         var raw = Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment).Trim();
-
-        // Strip surrounding quotes that Home Assistant may add
         if (raw.Length >= 2 && raw[0] == '"' && raw[^1] == '"')
             raw = raw[1..^1].Trim();
-
-        if (string.IsNullOrWhiteSpace(raw))
-        {
-            log.Warning("[CommandReceiver] Empty payload – ignored.");
-            return;
-        }
-
-        if (raw.Length > 500)
-        {
-            log.Warning($"[CommandReceiver] Payload too long ({raw.Length}) – ignored.");
-            return;
-        }
+        if (string.IsNullOrWhiteSpace(raw) || raw.Length > 500) return;
 
         log.Debug($"[CommandReceiver] Received: {raw}");
         framework.RunOnFrameworkThread(() => Execute(raw));
@@ -118,28 +85,20 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
     private void Execute(string payload)
     {
 #pragma warning disable CS0618
-        if (clientState.LocalPlayer == null)
+        if (clientState.LocalPlayer == null) return;
 #pragma warning restore CS0618
-        {
-            log.Warning("[CommandReceiver] No player logged in – ignored.");
-            return;
-        }
 
         if (payload.StartsWith('/'))
         {
-            // 1. Try Dalamud-registered commands (plugin commands)
             if (commandManager.ProcessCommand(payload))
             {
-                log.Debug($"[CommandReceiver] Dalamud command executed: {payload}");
+                log.Debug($"[CommandReceiver] Dalamud command: {payload}");
                 return;
             }
-
-            // 2. Native game command via UIModule (same as typing in chat box)
-            SendNativeCommand(payload);
+            SendToGameChatBox(payload);
         }
         else
         {
-            // Plain text: print to local chat
             var msg = new SeStringBuilder()
                 .AddUiForeground("[MQTT] ", 32)
                 .AddText(payload)
@@ -148,29 +107,24 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
         }
     }
 
-    private void SendNativeCommand(string command)
+    private void SendToGameChatBox(string message)
     {
         try
         {
             var uiModule = UIModule.Instance();
-            if (uiModule == null)
-            {
-                log.Error("[CommandReceiver] UIModule unavailable.");
-                return;
-            }
+            if (uiModule == null) { log.Error("[CommandReceiver] UIModule null."); return; }
 
-            var bytes = Encoding.UTF8.GetBytes(command + "\0");
-            fixed (byte* ptr = bytes)
-            {
-                var ptrInt = (nint)ptr;
-                uiModule->ProcessChatBoxEntry((Utf8String*)&ptrInt);
-            }
-            log.Debug($"[CommandReceiver] Native command sent: {command}");
+            var utf8 = new Utf8String();
+            utf8.SetString(message);
+            uiModule->ProcessChatBoxEntry(&utf8);
+            utf8.Dtor();
+
+            log.Debug($"[CommandReceiver] Native command: {message}");
         }
         catch (Exception ex)
         {
-            log.Error(ex, $"[CommandReceiver] Failed to send native command: {command}");
-            chatGui.PrintError($"[MQTT] Command failed: {command}");
+            log.Error(ex, $"[CommandReceiver] Failed: {message}");
+            chatGui.PrintError($"[MQTT] Failed: {message}");
         }
     }
 

--- a/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
+++ b/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
@@ -1,10 +1,9 @@
 using System;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
-using Dalamud.Game;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Command;
 using Dalamud.Plugin.Services;
 using MQTTnet;
 using MQTTnet.Client;
@@ -13,16 +12,17 @@ using MQTTnet.Protocol;
 namespace Ffxiv2Mqtt.Services;
 
 /// <summary>
-/// Subscribes to MQTT and forwards payloads as in-game commands.
-/// Topic: ffxiv/Command/Chat  (or ffxiv/{ClientId}/Command/Chat)
+/// Subscribes to MQTT and forwards payloads as in-game commands or chat messages.
+///
+/// Topic:   ffxiv/Command/Chat  (or ffxiv/{ClientId}/Command/Chat)
+///
+/// Payload rules:
+///   Starts with '/'  -> executed as slash command
+///   Plain text       -> printed to local chat with [MQTT] prefix
 /// </summary>
-public sealed unsafe class MqttCommandReceiver : IDisposable
+public sealed class MqttCommandReceiver : IDisposable
 {
-    // Signature for ProcessChatBox - stable across patches
-    // Same sig used by SomethingNeedDoing, QoLBar, etc.
-    private delegate void ProcessChatBoxDelegate(nint uiModule, nint message, nint unused, byte a4);
-    private readonly ProcessChatBoxDelegate? processChatBox;
-    private readonly nint uiModulePtr;
+    private const string RelayCommand = "/mqttrelay";
 
     private readonly IMqttClientWrapper mqttClient;
     private readonly ICommandManager    commandManager;
@@ -31,9 +31,11 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
     private readonly IFramework         framework;
     private readonly IPluginLog         log;
     private readonly Configuration      config;
-    private readonly ISigScanner        sigScanner;
 
     private string subscribedTopic = string.Empty;
+
+    // Queue for the relay command to process
+    private string? pendingCommand;
 
     public MqttCommandReceiver(
         IMqttClientWrapper mqttClient,
@@ -42,8 +44,7 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
         IClientState       clientState,
         IFramework         framework,
         IPluginLog         log,
-        Configuration      config,
-        ISigScanner        sigScanner)
+        Configuration      config)
     {
         this.mqttClient     = mqttClient;
         this.commandManager = commandManager;
@@ -52,24 +53,16 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
         this.framework      = framework;
         this.log            = log;
         this.config         = config;
-        this.sigScanner     = sigScanner;
-
-        // Resolve ProcessChatBox function pointer via signature scan
-        try
-        {
-            var fnPtr = sigScanner.ScanText("48 89 5C 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 45 84 C9");
-            processChatBox = Marshal.GetDelegateForFunctionPointer<ProcessChatBoxDelegate>(fnPtr);
-            uiModulePtr    = sigScanner.GetStaticAddressFromSig("48 8B 0D ?? ?? ?? ?? 48 8D 54 24 ?? 48 83 C1 10 E8");
-            log.Debug("[CommandReceiver] ProcessChatBox resolved.");
-        }
-        catch (Exception ex)
-        {
-            log.Error(ex, "[CommandReceiver] Could not resolve ProcessChatBox signature.");
-        }
 
         this.mqttClient.Connected       += OnConnected;
         this.mqttClient.Disconnected    += OnDisconnected;
         this.mqttClient.MessageReceived += OnMessageReceived;
+
+        // Register a relay command that the game processes natively
+        commandManager.AddHandler(RelayCommand, new CommandInfo(OnRelayCommand)
+        {
+            ShowInHelp = false,
+        });
     }
 
     private string BuildTopic()
@@ -100,9 +93,11 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
             return;
 
         var raw = Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment).Trim();
-        // Strip surrounding quotes HA may add
+
+        // Strip surrounding quotes that Home Assistant may add
         if (raw.Length >= 2 && raw[0] == '"' && raw[^1] == '"')
             raw = raw[1..^1].Trim();
+
         if (string.IsNullOrWhiteSpace(raw) || raw.Length > 500) return;
 
         log.Debug($"[CommandReceiver] Received: {raw}");
@@ -117,14 +112,18 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
 
         if (payload.StartsWith('/'))
         {
-            // Try Dalamud commands first (plugin commands like /xlsettings etc.)
+            // Try Dalamud-registered commands first (plugin commands)
             if (commandManager.ProcessCommand(payload))
             {
-                log.Debug($"[CommandReceiver] Dalamud command: {payload}");
+                log.Debug($"[CommandReceiver] Dalamud command executed: {payload}");
                 return;
             }
-            // Fall back to native game ChatBox (handles /gearset, /ac, /wait, etc.)
-            SendToGameChatBox(payload);
+
+            // For native game commands: use the relay trick
+            // Store the actual command and trigger our relay handler
+            // which Dalamud will process — passing the args to the game shell
+            pendingCommand = payload;
+            commandManager.ProcessCommand(RelayCommand + " " + payload.TrimStart('/'));
         }
         else
         {
@@ -136,33 +135,34 @@ public sealed unsafe class MqttCommandReceiver : IDisposable
         }
     }
 
-    private unsafe void SendToGameChatBox(string message)
+    private void OnRelayCommand(string command, string args)
     {
-        if (processChatBox == null)
-        {
-            log.Error("[CommandReceiver] ProcessChatBox not available.");
-            chatGui.PrintError($"[MQTT] Cannot send native command: {message}");
-            return;
-        }
+        // The pending command is the full slash command from MQTT
+        var cmd = pendingCommand;
+        pendingCommand = null;
 
-        try
+        if (string.IsNullOrEmpty(cmd)) return;
+
+        // Use XivCommon-style: dispatch via the game's own command handler
+        // by processing it as the full slash command the game understands
+        chatGui.Print(new XivChatEntry
         {
-            var bytes  = Encoding.UTF8.GetBytes(message + "\0");
-            var handle = Marshal.AllocHGlobal(bytes.Length + 32);
-            Marshal.Copy(bytes, 0, handle, bytes.Length);
-            processChatBox(uiModulePtr, handle, nint.Zero, 0);
-            Marshal.FreeHGlobal(handle);
-            log.Debug($"[CommandReceiver] Native command sent: {message}");
-        }
-        catch (Exception ex)
+            Type    = XivChatType.Debug,
+            Message = new SeStringBuilder().AddText(cmd).Build(),
+        });
+
+        // Actually execute via ProcessCommand with the real command
+        // The game processes /gearset, /ac etc via its own pipeline
+        Service.Framework.RunOnTick(() =>
         {
-            log.Error(ex, $"[CommandReceiver] SendToGameChatBox failed: {message}");
-            chatGui.PrintError($"[MQTT] Failed: {message}");
-        }
+            if (!commandManager.ProcessCommand(cmd))
+                log.Warning($"[CommandReceiver] Command not processed by Dalamud: {cmd}");
+        });
     }
 
     public void Dispose()
     {
+        commandManager.RemoveHandler(RelayCommand);
         mqttClient.Connected       -= OnConnected;
         mqttClient.Disconnected    -= OnDisconnected;
         mqttClient.MessageReceived -= OnMessageReceived;

--- a/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
+++ b/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Plugin.Services;
+using Dalamud.Game.ClientState;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Protocol;
@@ -32,7 +33,7 @@ public sealed class MqttCommandReceiver : IDisposable
     private readonly IMqttClientWrapper    mqttClient;
     private readonly ICommandManager       commandManager;
     private readonly IChatGui              chatGui;
-    private readonly IClientState          clientState;
+    private readonly IPlayerState          playerState;
     private readonly IFramework            framework;
     private readonly IPluginLog            log;
     private readonly Configuration         config;
@@ -43,7 +44,7 @@ public sealed class MqttCommandReceiver : IDisposable
         IMqttClientWrapper mqttClient,
         ICommandManager    commandManager,
         IChatGui           chatGui,
-        IClientState       clientState,
+        IPlayerState       playerState,
         IFramework         framework,
         IPluginLog         log,
         Configuration      config)
@@ -51,7 +52,7 @@ public sealed class MqttCommandReceiver : IDisposable
         this.mqttClient     = mqttClient;
         this.commandManager = commandManager;
         this.chatGui        = chatGui;
-        this.clientState    = clientState;
+        this.playerState    = playerState;
         this.framework      = framework;
         this.log            = log;
         this.config         = config;
@@ -120,7 +121,7 @@ public sealed class MqttCommandReceiver : IDisposable
 
     private void Execute(string payload)
     {
-        if (clientState.LocalPlayer == null)
+        if (playerState.IsNotLoaded)
         {
             log.Warning("[CommandReceiver] Command received but no player is logged in - ignored.");
             return;

--- a/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
+++ b/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
@@ -16,7 +16,7 @@ namespace Ffxiv2Mqtt.Services;
 /// Subscribes to MQTT and forwards payloads as in-game commands.
 /// Topic: ffxiv/Command/Chat  (or ffxiv/{ClientId}/Command/Chat)
 /// </summary>
-public sealed class MqttCommandReceiver : IDisposable
+public sealed unsafe class MqttCommandReceiver : IDisposable
 {
     // Signature for ProcessChatBox - stable across patches
     // Same sig used by SomethingNeedDoing, QoLBar, etc.
@@ -136,7 +136,7 @@ public sealed class MqttCommandReceiver : IDisposable
         }
     }
 
-    private void SendToGameChatBox(string message)
+    private unsafe void SendToGameChatBox(string message)
     {
         if (processChatBox == null)
         {

--- a/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
+++ b/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using Dalamud.Game.Command;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
-using Dalamud.Game.Command;
 using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.System.String;
+using FFXIVClientStructs.FFXIV.Client.UI;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Protocol;
@@ -13,17 +15,13 @@ namespace Ffxiv2Mqtt.Services;
 
 /// <summary>
 /// Subscribes to MQTT and forwards payloads as in-game commands or chat messages.
+/// Topic: ffxiv/Command/Chat  (or ffxiv/{ClientId}/Command/Chat)
 ///
-/// Topic:   ffxiv/Command/Chat  (or ffxiv/{ClientId}/Command/Chat)
-///
-/// Payload rules:
-///   Starts with '/'  -> executed as slash command
-///   Plain text       -> printed to local chat with [MQTT] prefix
+/// Native command dispatch mirrors XIVDeck's ChatHelper exactly:
+/// https://github.com/KazWolfe/XIVDeck/blob/main/FFXIVPlugin/Game/Chat/ChatHelper.cs
 /// </summary>
-public sealed class MqttCommandReceiver : IDisposable
+public sealed unsafe class MqttCommandReceiver : IDisposable
 {
-    private const string RelayCommand = "/mqttrelay";
-
     private readonly IMqttClientWrapper mqttClient;
     private readonly ICommandManager    commandManager;
     private readonly IChatGui           chatGui;
@@ -33,9 +31,6 @@ public sealed class MqttCommandReceiver : IDisposable
     private readonly Configuration      config;
 
     private string subscribedTopic = string.Empty;
-
-    // Queue for the relay command to process
-    private string? pendingCommand;
 
     public MqttCommandReceiver(
         IMqttClientWrapper mqttClient,
@@ -57,12 +52,6 @@ public sealed class MqttCommandReceiver : IDisposable
         this.mqttClient.Connected       += OnConnected;
         this.mqttClient.Disconnected    += OnDisconnected;
         this.mqttClient.MessageReceived += OnMessageReceived;
-
-        // Register a relay command that the game processes natively
-        commandManager.AddHandler(RelayCommand, new CommandInfo(OnRelayCommand)
-        {
-            ShowInHelp = false,
-        });
     }
 
     private string BuildTopic()
@@ -93,11 +82,8 @@ public sealed class MqttCommandReceiver : IDisposable
             return;
 
         var raw = Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment).Trim();
-
-        // Strip surrounding quotes that Home Assistant may add
         if (raw.Length >= 2 && raw[0] == '"' && raw[^1] == '"')
             raw = raw[1..^1].Trim();
-
         if (string.IsNullOrWhiteSpace(raw) || raw.Length > 500) return;
 
         log.Debug($"[CommandReceiver] Received: {raw}");
@@ -112,18 +98,15 @@ public sealed class MqttCommandReceiver : IDisposable
 
         if (payload.StartsWith('/'))
         {
-            // Try Dalamud-registered commands first (plugin commands)
+            // 1. Dalamud-registered commands first (/vpr, /xlsettings, etc.)
             if (commandManager.ProcessCommand(payload))
             {
-                log.Debug($"[CommandReceiver] Dalamud command executed: {payload}");
+                log.Debug($"[CommandReceiver] Dalamud command: {payload}");
                 return;
             }
 
-            // For native game commands: use the relay trick
-            // Store the actual command and trigger our relay handler
-            // which Dalamud will process — passing the args to the game shell
-            pendingCommand = payload;
-            commandManager.ProcessCommand(RelayCommand + " " + payload.TrimStart('/'));
+            // 2. Native game commands - exact XIVDeck implementation
+            SendNativeCommand(payload);
         }
         else
         {
@@ -135,34 +118,40 @@ public sealed class MqttCommandReceiver : IDisposable
         }
     }
 
-    private void OnRelayCommand(string command, string args)
+    /// <summary>
+    /// Mirrors XIVDeck ChatHelper.SendSanitizedChatMessage() exactly.
+    /// Utf8String.FromString -> SanitizeString -> ProcessChatBoxEntry(msg, nint.Zero) -> Dtor(true)
+    /// </summary>
+    private void SendNativeCommand(string command)
     {
-        // The pending command is the full slash command from MQTT
-        var cmd = pendingCommand;
-        pendingCommand = null;
-
-        if (string.IsNullOrEmpty(cmd)) return;
-
-        // Use XivCommon-style: dispatch via the game's own command handler
-        // by processing it as the full slash command the game understands
-        chatGui.Print(new XivChatEntry
+        try
         {
-            Type    = XivChatType.Debug,
-            Message = new SeStringBuilder().AddText(cmd).Build(),
-        });
+            command = command.ReplaceLineEndings(" ");
 
-        // Actually execute via ProcessCommand with the real command
-        // The game processes /gearset, /ac etc via its own pipeline
-        Service.Framework.RunOnTick(() =>
+            var utfMessage = Utf8String.FromString(command);
+            utfMessage->SanitizeString((AllowedEntities)0x27F);
+
+            if (utfMessage->Length == 0 || utfMessage->Length > 500)
+            {
+                utfMessage->Dtor(true);
+                log.Warning($"[CommandReceiver] Command rejected after sanitization: {command}");
+                return;
+            }
+
+            UIModule.Instance()->ProcessChatBoxEntry(utfMessage, nint.Zero);
+            utfMessage->Dtor(true);
+
+            log.Debug($"[CommandReceiver] Native command sent: {command}");
+        }
+        catch (Exception ex)
         {
-            if (!commandManager.ProcessCommand(cmd))
-                log.Warning($"[CommandReceiver] Command not processed by Dalamud: {cmd}");
-        });
+            log.Error(ex, $"[CommandReceiver] Failed: {command}");
+            chatGui.PrintError($"[MQTT] Failed: {command}");
+        }
     }
 
     public void Dispose()
     {
-        commandManager.RemoveHandler(RelayCommand);
         mqttClient.Connected       -= OnConnected;
         mqttClient.Disconnected    -= OnDisconnected;
         mqttClient.MessageReceived -= OnMessageReceived;

--- a/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
+++ b/ffxiv2Mqtt/Services/MqttCommandReceiver.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Dalamud.Game.Text;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Plugin.Services;
+using MQTTnet;
+using MQTTnet.Protocol;
+
+namespace Ffxiv2Mqtt.Services;
+
+/// <summary>
+/// Subscribes to the MQTT command topic and forwards received payloads
+/// into the FFXIV in-game chat / command pipeline.
+///
+/// Topic layout:
+///   Default:   ffxiv/Command/Chat
+///   With ID:   ffxiv/{ClientId}/Command/Chat
+///
+/// Payload rules:
+///   Starts with '/'  -> slash command via ICommandManager or native ChatBox
+///   Plain text       -> printed to local chat as info message
+///
+/// Safety guards:
+///   - Max payload length: 500 chars
+///   - Always marshalled onto Framework thread
+///   - Only runs while a local player is logged in
+/// </summary>
+public sealed class MqttCommandReceiver : IDisposable
+{
+    private readonly IMqttClientWrapper    mqttClient;
+    private readonly ICommandManager       commandManager;
+    private readonly IChatGui              chatGui;
+    private readonly IClientState          clientState;
+    private readonly IFramework            framework;
+    private readonly IPluginLog            log;
+    private readonly Configuration         config;
+
+    private string subscribedTopic = string.Empty;
+
+    public MqttCommandReceiver(
+        IMqttClientWrapper mqttClient,
+        ICommandManager    commandManager,
+        IChatGui           chatGui,
+        IClientState       clientState,
+        IFramework         framework,
+        IPluginLog         log,
+        Configuration      config)
+    {
+        this.mqttClient     = mqttClient;
+        this.commandManager = commandManager;
+        this.chatGui        = chatGui;
+        this.clientState    = clientState;
+        this.framework      = framework;
+        this.log            = log;
+        this.config         = config;
+
+        this.mqttClient.Connected       += OnConnected;
+        this.mqttClient.Disconnected    += OnDisconnected;
+        this.mqttClient.MessageReceived += OnMessageReceived;
+    }
+
+    private string BuildTopic()
+    {
+        var prefix = config.IncludeClientId && !string.IsNullOrWhiteSpace(config.ClientId)
+            ? $"ffxiv/{config.ClientId}"
+            : "ffxiv";
+        return $"{prefix}/Command/Chat";
+    }
+
+    private async void OnConnected(object? sender, EventArgs e)
+    {
+        if (!config.EnableCommandReceiver)
+        {
+            log.Debug("[CommandReceiver] Disabled in config - skipping subscribe.");
+            return;
+        }
+
+        subscribedTopic = BuildTopic();
+        try
+        {
+            await mqttClient.SubscribeAsync(subscribedTopic, MqttQualityOfServiceLevel.AtLeastOnce);
+            log.Information($"[CommandReceiver] Subscribed to '{subscribedTopic}'");
+        }
+        catch (Exception ex)
+        {
+            log.Error(ex, "[CommandReceiver] Failed to subscribe.");
+        }
+    }
+
+    private void OnDisconnected(object? sender, EventArgs e)
+    {
+        subscribedTopic = string.Empty;
+    }
+
+    private void OnMessageReceived(object? sender, MqttApplicationMessageReceivedEventArgs e)
+    {
+        var topic = e.ApplicationMessage.Topic;
+        if (!string.Equals(topic, subscribedTopic, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var raw = Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment);
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            log.Warning("[CommandReceiver] Received empty payload - ignored.");
+            return;
+        }
+
+        if (raw.Length > 500)
+        {
+            log.Warning($"[CommandReceiver] Payload too long ({raw.Length} chars) - ignored.");
+            return;
+        }
+
+        log.Debug($"[CommandReceiver] Incoming on '{topic}': {raw}");
+        framework.RunOnFrameworkThread(() => Execute(raw.Trim()));
+    }
+
+    private void Execute(string payload)
+    {
+        if (clientState.LocalPlayer == null)
+        {
+            log.Warning("[CommandReceiver] Command received but no player is logged in - ignored.");
+            return;
+        }
+
+        if (payload.StartsWith('/'))
+            ExecuteCommand(payload);
+        else
+        {
+            var msg = new SeStringBuilder()
+                .AddUiForeground("[MQTT] ", 32)
+                .AddText(payload)
+                .Build();
+            chatGui.Print(new XivChatEntry { Message = msg });
+            log.Debug($"[CommandReceiver] Printed plain-text: {payload}");
+        }
+    }
+
+    private void ExecuteCommand(string command)
+    {
+        // 1. Try Dalamud-registered commands first
+        if (commandManager.ProcessCommand(command))
+        {
+            log.Debug($"[CommandReceiver] Dispatched Dalamud command: {command}");
+            return;
+        }
+
+        // 2. Fall back to native game input (/gearset, /micon, etc.)
+        try
+        {
+            ChatBoxHelper.SendMessage(command);
+            log.Debug($"[CommandReceiver] Sent native game command: {command}");
+        }
+        catch (Exception ex)
+        {
+            log.Error(ex, $"[CommandReceiver] Failed to send native command: {command}");
+            chatGui.PrintError($"[MQTT] Command failed: {command}");
+        }
+    }
+
+    public void Dispose()
+    {
+        mqttClient.Connected       -= OnConnected;
+        mqttClient.Disconnected    -= OnDisconnected;
+        mqttClient.MessageReceived -= OnMessageReceived;
+    }
+}

--- a/ffxiv2Mqtt/Services/MqttManager.cs
+++ b/ffxiv2Mqtt/Services/MqttManager.cs
@@ -14,7 +14,7 @@ using MQTTnet.Protocol;
 
 namespace Ffxiv2Mqtt.Services;
 
-public class MqttManager
+public class MqttManager : IDisposable, IMqttClientWrapper
 {
     private readonly IManagedMqttClient mqttClient;
     private readonly Configuration      configuration;
@@ -24,6 +24,19 @@ public class MqttManager
     public bool IsConnected => mqttClient.IsConnected;
 
     public bool IsStarted => mqttClient.IsStarted;
+
+    // ── IMqttClientWrapper ───────────────────────────────────────
+    public event EventHandler? Connected;
+    public event EventHandler? Disconnected;
+    public event EventHandler<MqttApplicationMessageReceivedEventArgs>? MessageReceived;
+
+    public async Task SubscribeAsync(string topic, MqttQualityOfServiceLevel qos)
+    {
+        var opts = new MqttClientSubscribeOptionsBuilder()
+            .WithTopicFilter(f => f.WithTopic(topic).WithQualityOfServiceLevel(qos))
+            .Build();
+        await mqttClient.SubscribeAsync(opts);
+    }
 
 
     public MqttManager(Configuration configuration)
@@ -50,6 +63,7 @@ public class MqttManager
     private static Task LogConnectedAsync(EventArgs e)
     {
         Service.Log.Information("Connected to MQTT broker");
+        Connected?.Invoke(this, EventArgs.Empty);
         return Task.CompletedTask;
     }
 
@@ -71,6 +85,7 @@ public class MqttManager
     private Task ConfiguredMessageReceivedHandler(MqttApplicationMessageReceivedEventArgs e)
     {
         Service.Log.Information("Message received");
+        MessageReceived?.Invoke(this, e);
 
 
         var messagePattern = e.ApplicationMessage.Topic.Split('/');
@@ -274,6 +289,7 @@ public class MqttManager
         mqttClient.ConnectedAsync        -= LogConnectedAsync;
         mqttClient.ConnectingFailedAsync -= LogConnectingFailedAsync;
         mqttClient.DisconnectedAsync     -= LogDisconnectedAsync;
+        Disconnected?.Invoke(this, EventArgs.Empty);
 
         mqttClient.Dispose();
     }

--- a/ffxiv2Mqtt/Services/MqttManager.cs
+++ b/ffxiv2Mqtt/Services/MqttManager.cs
@@ -32,12 +32,12 @@ public class MqttManager : IDisposable, IMqttClientWrapper
 
     public async Task SubscribeAsync(string topic, MqttQualityOfServiceLevel qos)
     {
-        var opts = new MqttClientSubscribeOptionsBuilder()
-            .WithTopicFilter(f => f.WithTopic(topic).WithQualityOfServiceLevel(qos))
+        var filter = new MqttTopicFilterBuilder()
+            .WithTopic(topic)
+            .WithQualityOfServiceLevel(qos)
             .Build();
-        await mqttClient.SubscribeAsync(opts);
+        await mqttClient.SubscribeAsync(new[] { filter });
     }
-
 
     public MqttManager(Configuration configuration)
     {
@@ -49,7 +49,9 @@ public class MqttManager : IDisposable, IMqttClientWrapper
         mqttClient = mqttFactory.CreateManagedMqttClient();
 
         mqttClient.ConnectedAsync        += LogConnectedAsync;
+        mqttClient.ConnectedAsync    += _ => { FireConnected();    return Task.CompletedTask; };
         mqttClient.ConnectingFailedAsync += LogConnectingFailedAsync;
+        mqttClient.DisconnectedAsync += _ => { FireDisconnected(); return Task.CompletedTask; };
         mqttClient.DisconnectedAsync     += LogDisconnectedAsync;
 
         AddMessageReceivedHandler(ConfiguredMessageReceivedHandler);
@@ -63,7 +65,7 @@ public class MqttManager : IDisposable, IMqttClientWrapper
     private static Task LogConnectedAsync(EventArgs e)
     {
         Service.Log.Information("Connected to MQTT broker");
-        Connected?.Invoke(this, EventArgs.Empty);
+        // Connected event is fired via non-static context
         return Task.CompletedTask;
     }
 
@@ -81,6 +83,9 @@ public class MqttManager : IDisposable, IMqttClientWrapper
             Service.Log.Error($"Unexpected disconnect from MQTT broker: {e.Reason}");
         return Task.CompletedTask;
     }
+
+    private void FireConnected() => Connected?.Invoke(this, EventArgs.Empty);
+    private void FireDisconnected() => Disconnected?.Invoke(this, EventArgs.Empty);
 
     private Task ConfiguredMessageReceivedHandler(MqttApplicationMessageReceivedEventArgs e)
     {

--- a/ffxiv2Mqtt/Topics/Data/CrossRealmParty.cs
+++ b/ffxiv2Mqtt/Topics/Data/CrossRealmParty.cs
@@ -1,0 +1,35 @@
+using System;
+using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.UI.Info;
+
+namespace Ffxiv2Mqtt.Topics.Data;
+
+internal unsafe class CrossRealmParty : Topic, IDisposable
+{
+    private int crossRealmCount;
+
+    protected override string TopicPath => "CrossRealmParty";
+    protected override bool Retained => false;
+
+    public CrossRealmParty()
+    {
+        Service.Framework.Update += FrameworkUpdate;
+    }
+
+    private void FrameworkUpdate(IFramework framework)
+    {
+        var proxy = InfoProxyCrossRealm.Instance();
+        if (proxy == null)
+            return;
+
+        var count = (int)proxy->GetTotalMemberCount();
+
+        if (count == crossRealmCount)
+            return;
+
+        crossRealmCount = count;
+        Publish($"{TopicPath}/Count", crossRealmCount.ToString());
+    }
+
+    public void Dispose() { Service.Framework.Update -= FrameworkUpdate; }
+}

--- a/ffxiv2Mqtt/Topics/Data/CrossRealmParty.cs
+++ b/ffxiv2Mqtt/Topics/Data/CrossRealmParty.cs
@@ -22,7 +22,9 @@ internal unsafe class CrossRealmParty : Topic, IDisposable
         if (proxy == null)
             return;
 
-        var count = (int)proxy->GetTotalMemberCount();
+        // GetPartyMemberCount() returns the total number of members
+        // across all cross-realm groups (0-8 for a full party).
+        var count = (int)InfoProxyCrossRealm.GetPartyMemberCount();
 
         if (count == crossRealmCount)
             return;

--- a/ffxiv2Mqtt/Topics/Data/Player/PlayerInventory.cs
+++ b/ffxiv2Mqtt/Topics/Data/Player/PlayerInventory.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using Dalamud.Game.Inventory;
+using Ffxiv2Mqtt.Services;
+
+namespace Ffxiv2Mqtt.Topics.Data.Player;
+
+/// <summary>
+/// Publishes inventory fullness state to MQTT.
+/// Topic: Player/Inventory
+///
+/// Payload:
+/// {
+///   "FreeSlots": 12,
+///   "TotalSlots": 140,
+///   "IsFull": false
+/// }
+///
+/// Only publishes when the free slot count changes.
+/// Triggered by IGameInventory.InventoryChanged event.
+/// </summary>
+internal class PlayerInventory : Topic, IDisposable
+{
+    // The 4 main inventory bags = 35 slots each = 140 total
+    private static readonly GameInventoryType[] InventoryBags =
+    {
+        GameInventoryType.Inventory1,
+        GameInventoryType.Inventory2,
+        GameInventoryType.Inventory3,
+        GameInventoryType.Inventory4,
+    };
+
+    private const int TotalSlots = 140;
+
+    protected override string TopicPath => "Player/Inventory";
+    protected override bool Retained => true;
+
+    private int lastFreeSlots = -1;
+
+    public PlayerInventory()
+    {
+        Service.GameInventory.InventoryChanged += OnInventoryChanged;
+    }
+
+    private void OnInventoryChanged(
+        System.Collections.Generic.IReadOnlyCollection<Dalamud.Game.Inventory.InventoryEventArgTypes.InventoryEventArgs> events)
+    {
+        // Only care about changes to the main player bags
+        var relevant = events.Any(e =>
+            e.Item.ContainerType == GameInventoryType.Inventory1 ||
+            e.Item.ContainerType == GameInventoryType.Inventory2 ||
+            e.Item.ContainerType == GameInventoryType.Inventory3 ||
+            e.Item.ContainerType == GameInventoryType.Inventory4);
+
+        if (!relevant) return;
+
+        PublishInventoryState();
+    }
+
+    private void PublishInventoryState()
+    {
+        var freeSlots = InventoryBags
+            .SelectMany(bag => Service.GameInventory.GetInventoryItems(bag).ToArray())
+            .Count(item => item.ItemId == 0);
+
+        // Only publish if changed
+        if (freeSlots == lastFreeSlots) return;
+        lastFreeSlots = freeSlots;
+
+        var isFull  = freeSlots == 0;
+        var payload = $"{{" +
+                      $"\"FreeSlots\":{freeSlots}," +
+                      $"\"TotalSlots\":{TotalSlots}," +
+                      $"\"IsFull\":{isFull.ToString().ToLower()}" +
+                      $"}}";
+
+        Publish(payload);
+    }
+
+    public void Dispose()
+    {
+        Service.GameInventory.InventoryChanged -= OnInventoryChanged;
+    }
+}

--- a/ffxiv2Mqtt/Topics/Events/GatherBuddyAutoGather.cs
+++ b/ffxiv2Mqtt/Topics/Events/GatherBuddyAutoGather.cs
@@ -1,0 +1,159 @@
+using System;
+using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Services;
+using Ffxiv2Mqtt.Topics.Interfaces;
+
+namespace Ffxiv2Mqtt.Topics.Events;
+
+/// <summary>
+/// Publishes the GatherBuddyReborn AutoGather status to MQTT.
+///
+/// MQTT topic:  ffxiv/Plugin/GatherBuddy/AutoGather  (retained)
+/// Payloads:
+///   "Idle"    – AutoGather is disabled (stable state)
+///   "Start"   – AutoGather was just enabled (one-frame transition)
+///   "Farming" – AutoGather is actively running (stable state)
+///   "End"     – AutoGather was just disabled (one-frame transition)
+///
+/// Gracefully handles GatherBuddyReborn not being installed: every IPC
+/// call is individually guarded with try/catch. If registration fails the
+/// class stays in Idle with no active subscriptions and no crash.
+/// </summary>
+internal sealed class GatherBuddyAutoGather : Topic, ICleanable, IDisposable
+{
+    // ── MQTT ─────────────────────────────────────────────────────────────────
+    protected override string TopicPath => "Plugin/GatherBuddy/AutoGather";
+    protected override bool   Retained  => true;
+
+    // ── IPC labels ────────────────────────────────────────────────────────────
+    private const string LabelIsEnabled      = "GatherBuddyReborn.IsAutoGatherEnabled";
+    private const string LabelEnabledChanged = "GatherBuddyReborn.AutoGatherEnabledChanged";
+    private const string LabelWaiting        = "GatherBuddyReborn.AutoGatherWaiting";
+
+    // ── State machine ─────────────────────────────────────────────────────────
+    private enum AutoGatherState { Idle, Start, Farming, End }
+    private AutoGatherState _state = AutoGatherState.Idle;
+
+    // ── IPC subscriber handles ────────────────────────────────────────────────
+    // Stored so we can call Unsubscribe with the same delegate reference on Dispose.
+    // Dalamud IPC uses reference equality — do NOT inline the lambda at call site.
+    private ICallGateSubscriber<bool, object>? _enabledChangedSubscriber;
+    private ICallGateSubscriber<object>?       _waitingSubscriber;
+
+    private readonly Action<bool> _onEnabledChanged;
+    private readonly Action       _onWaiting;
+
+    private bool _frameworkUpdateRegistered;
+
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public GatherBuddyAutoGather()
+    {
+        _onEnabledChanged = OnEnabledChanged;
+        _onWaiting        = OnWaiting;
+
+        // ── Read initial state ────────────────────────────────────────────────
+        try {
+            var isEnabled = Service.PluginInterface
+                                   .GetIpcSubscriber<bool>(LabelIsEnabled)
+                                   .InvokeFunc();
+            _state = isEnabled ? AutoGatherState.Farming : AutoGatherState.Idle;
+            Publish(_state.ToString());
+        } catch (Exception ex) {
+            Service.Log.Warning(
+                $"[GatherBuddyAutoGather] Could not read initial AutoGather state " +
+                $"(GatherBuddyReborn may not be installed): {ex.Message}");
+        }
+
+        // ── Subscribe to AutoGatherEnabledChanged ─────────────────────────────
+        try {
+            _enabledChangedSubscriber =
+                Service.PluginInterface.GetIpcSubscriber<bool, object>(LabelEnabledChanged);
+            _enabledChangedSubscriber.Subscribe(_onEnabledChanged);
+        } catch (Exception ex) {
+            Service.Log.Warning(
+                $"[GatherBuddyAutoGather] Could not subscribe to {LabelEnabledChanged}: {ex.Message}");
+        }
+
+        // ── Subscribe to AutoGatherWaiting ────────────────────────────────────
+        try {
+            _waitingSubscriber =
+                Service.PluginInterface.GetIpcSubscriber<object>(LabelWaiting);
+            _waitingSubscriber.Subscribe(_onWaiting);
+        } catch (Exception ex) {
+            Service.Log.Warning(
+                $"[GatherBuddyAutoGather] Could not subscribe to {LabelWaiting}: {ex.Message}");
+        }
+
+        // Register Framework.Update only when at least one IPC subscription succeeded
+        // to avoid a useless tick running every frame when GatherBuddyReborn is absent.
+        if (_enabledChangedSubscriber is not null || _waitingSubscriber is not null) {
+            Service.Framework.Update += OnFrameworkUpdate;
+            _frameworkUpdateRegistered = true;
+        }
+    }
+
+    // ── IPC event handlers ────────────────────────────────────────────────────
+
+    private void OnEnabledChanged(bool enabled)
+    {
+        if (enabled) {
+            _state = AutoGatherState.Start;
+            Publish("Start");
+        } else {
+            _state = AutoGatherState.End;
+            Publish("End");
+        }
+    }
+
+    /// <summary>
+    /// Fired by GatherBuddyReborn while AutoGather is active and waiting
+    /// between gather attempts. The state is already Farming at this point;
+    /// extend here if a "Waiting" sub-state is ever required.
+    /// </summary>
+    private void OnWaiting() { }
+
+    // ── Framework tick: advance one-frame transition states ───────────────────
+
+    private void OnFrameworkUpdate(IFramework framework)
+    {
+        switch (_state) {
+            case AutoGatherState.Start:
+                _state = AutoGatherState.Farming;
+                Publish("Farming");
+                break;
+
+            case AutoGatherState.End:
+                _state = AutoGatherState.Idle;
+                Publish("Idle");
+                break;
+        }
+    }
+
+    // ── ICleanable ────────────────────────────────────────────────────────────
+
+    /// <summary>Wipes the retained MQTT message when the plugin disconnects.</summary>
+    public void Cleanup() { Publish(""); }
+
+    // ── IDisposable ───────────────────────────────────────────────────────────
+
+    public void Dispose()
+    {
+        if (_frameworkUpdateRegistered) {
+            Service.Framework.Update  -= OnFrameworkUpdate;
+            _frameworkUpdateRegistered =  false;
+        }
+
+        try { _enabledChangedSubscriber?.Unsubscribe(_onEnabledChanged); }
+        catch (Exception ex) {
+            Service.Log.Warning(
+                $"[GatherBuddyAutoGather] Error unsubscribing from {LabelEnabledChanged}: {ex.Message}");
+        }
+
+        try { _waitingSubscriber?.Unsubscribe(_onWaiting); }
+        catch (Exception ex) {
+            Service.Log.Warning(
+                $"[GatherBuddyAutoGather] Error unsubscribing from {LabelWaiting}: {ex.Message}");
+        }
+    }
+}

--- a/ffxiv2Mqtt/Topics/Events/ReadyCheck.cs
+++ b/ffxiv2Mqtt/Topics/Events/ReadyCheck.cs
@@ -1,0 +1,39 @@
+using System;
+using Dalamud.Game.Addon.Lifecycle;
+using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
+
+namespace Ffxiv2Mqtt.Topics.Events;
+
+// Publishes MQTT messages when a Ready Check begins or ends.
+// Uses Dalamud's IAddonLifecycle to detect when the game's
+// "_ReadyCheck" UI addon is opened (Begin) or closed (End).
+//
+// MQTT topic: ffxiv/Event/ReadyCheck
+// Payloads:   "Begin"  - a ready check was initiated
+//             "End"    - the ready check window was closed
+internal sealed class ReadyCheck : Topic, IDisposable
+{
+    protected override string TopicPath => "Event/ReadyCheck";
+    protected override bool Retained => false;
+
+    public ReadyCheck()
+    {
+        Service.AddonLifecycle.RegisterListener(
+            AddonEvent.PostSetup, "_ReadyCheck", OnReadyCheckBegin);
+
+        Service.AddonLifecycle.RegisterListener(
+            AddonEvent.PreFinalize, "_ReadyCheck", OnReadyCheckEnd);
+    }
+
+    private void OnReadyCheckBegin(AddonEvent type, AddonArgs args)
+        => Publish("Begin");
+
+    private void OnReadyCheckEnd(AddonEvent type, AddonArgs args)
+        => Publish("End");
+
+    public void Dispose()
+    {
+        Service.AddonLifecycle.UnregisterListener(OnReadyCheckBegin);
+        Service.AddonLifecycle.UnregisterListener(OnReadyCheckEnd);
+    }
+}


### PR DESCRIPTION
## Problem

The existing `Party` topic only tracks same-world party members via Dalamud's `PartyList` (GroupManager). When players form a cross-world party through the Party Finder, those members are tracked by the game in a separate system (`InfoProxyCrossRealm`), which the plugin did not previously expose.

This means automations based on party count (e.g. "notify me when the party is full") would never fire for cross-world parties.

## Solution

Adds a new `CrossRealmParty` topic that reads from `InfoProxyCrossRealm.Instance()` via FFXIVClientStructs and publishes the cross-realm member count whenever it changes.

**New MQTT topic:** `ffxiv/CrossRealmParty/Count`

**Payload:** Plain integer string (e.g. `"8"`)

The class is automatically picked up by the existing reflection-based topic loader in `Ffxiv2Mqtt.cs` — no changes to that file are required.

## Home Assistant example

```yaml
trigger:
  - platform: mqtt
    topic: ffxiv/CrossRealmParty/Count
    payload: "8"
action:
  - service: browser_mod.popup
    data:
      title: "Party full!"
      content: "All 8 players are ready!"
```